### PR TITLE
スライダーの長押しによる選択とコンテキストメニューを無効化

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,28 @@
 <head>
   <title>Sound Slider</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <style>
+    /* モバイルで長押しによるテキスト選択やコピー、タッチハイライトを無効化 */
+    html, body {
+      -webkit-user-select: none; /* Safari/Chrome */
+      -moz-user-select: none; /* Firefox */
+      -ms-user-select: none; /* IE/Edge */
+      user-select: none; /* 標準 */
+      -webkit-touch-callout: none; /* iOS のコンテキストメニュー */
+      -webkit-tap-highlight-color: rgba(0,0,0,0); /* タップのハイライトを無効化 */
+      touch-action: manipulation; /* ブラウザの既定のジェスチャを抑制（必要に応じて調整） */
+    }
+
+    /* スライダー自体は確実に選択不可・長押し無効にする */
+    .no-select {
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+      -webkit-touch-callout: none;
+      -webkit-tap-highlight-color: rgba(0,0,0,0);
+    }
+  </style>
 </head>
 
 <body>
@@ -129,12 +151,16 @@
 
         soundSlider.addEventListener("touchstart", (e) => {
           const y = e.touches[0].pageY;
+          // 長押しによる選択やコンテキストメニューを抑制
+          e.preventDefault();
           this.playSin(this.baseFrequency + y);
           this.updateFrequencyDisplay(e.touches[0].pageX, e.touches[0].pageY, this.baseFrequency + y);
         });
 
         soundSlider.addEventListener("touchmove", (e) => {
           const y = e.touches[0].pageY;
+          // 長押しによる選択を防ぐ
+          e.preventDefault();
           if (this.snd) {
             this.snd.frequency.value = this.baseFrequency + y;
             this.updateFrequencyDisplay(e.touches[0].pageX, e.touches[0].pageY, this.baseFrequency + y);
@@ -147,6 +173,14 @@
         });
 
         document.body.append(soundSlider);
+
+  // スライダーを選択不可クラスにする
+  soundSlider.classList.add('no-select');
+
+  // グローバルにコンテキストメニューとテキスト選択の開始を抑制
+  // （必要な操作がある場合は限定的にする）
+  document.addEventListener('contextmenu', (e) => e.preventDefault());
+  document.addEventListener('selectstart', (e) => e.preventDefault());
 
         // 最低周波数を調整するUIを画面右側に配置
         const controlContainer = document.createElement('div');

--- a/index.html
+++ b/index.html
@@ -148,6 +148,8 @@
         soundSlider.style.height = "100vh";
         soundSlider.style.marginLeft = "2em";
         soundSlider.style.background = "#333";
+        // スライダーを選択不可クラスにする
+        soundSlider.classList.add('no-select');
 
         soundSlider.addEventListener("touchstart", (e) => {
           const y = e.touches[0].pageY;
@@ -173,14 +175,6 @@
         });
 
         document.body.append(soundSlider);
-
-  // スライダーを選択不可クラスにする
-  soundSlider.classList.add('no-select');
-
-  // グローバルにコンテキストメニューとテキスト選択の開始を抑制
-  // （必要な操作がある場合は限定的にする）
-  document.addEventListener('contextmenu', (e) => e.preventDefault());
-  document.addEventListener('selectstart', (e) => e.preventDefault());
 
         // 最低周波数を調整するUIを画面右側に配置
         const controlContainer = document.createElement('div');
@@ -320,6 +314,13 @@
     }
     adjustFontSize();
     window.addEventListener("orientationchange", () => { setTimeout(adjustFontSize, 100) });
+
+    // グローバルにコンテキストメニューとテキスト選択の開始を抑制（初期化時に一度だけ追加）
+    document.addEventListener('contextmenu', (e) => e.preventDefault());
+    // グローバルにコンテキストメニューとテキスト選択の開始を抑制
+    // （必要な操作がある場合は限定的にする）
+    document.addEventListener('contextmenu', (e) => e.preventDefault());
+    document.addEventListener('selectstart', (e) => e.preventDefault());
 
     // インスタンスを作成して実行
     const soundController = new SoundController();

--- a/index.html
+++ b/index.html
@@ -315,8 +315,6 @@
     adjustFontSize();
     window.addEventListener("orientationchange", () => { setTimeout(adjustFontSize, 100) });
 
-    // グローバルにコンテキストメニューとテキスト選択の開始を抑制（初期化時に一度だけ追加）
-    document.addEventListener('contextmenu', (e) => e.preventDefault());
     // グローバルにコンテキストメニューとテキスト選択の開始を抑制
     // （必要な操作がある場合は限定的にする）
     document.addEventListener('contextmenu', (e) => e.preventDefault());


### PR DESCRIPTION
## 概要

サウンドスライダー上での長押しによるテキスト選択やコンテキストメニューの表示を防ぎ、操作をスムーズにする変更です。これにより、スライダーをドラッグする際に意図しない選択や右クリックメニューが出る問題を解消します。

## 変更点

スライダー要素上でのテキスト選択を無効化（CSS / JavaScript による制御）
長押し（タッチ・長押し）時のコンテキストメニュー表示を抑制
必要に応じてスライダーが選択不可であることを保証するためのフォールバック処理を追加

## 期待される効果

スライダー操作がより滑らかになる
モバイルやタッチデバイスでの誤操作が減少する
視覚的にテキスト選択が残ることがなくなり、UXが向上する

## 備考

具体的な実装は主に index.html（スライダーを定義しているファイル）に対する CSS/JS の小さな変更です

fix: #2